### PR TITLE
Handle GeometryTypes.Point.

### DIFF
--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -45,6 +45,10 @@ function support_vector_max(pt::gt.Vec{N, T}, direction, initial_guess::Tagged) 
     Tagged(SVector(pt))
 end
 
+function support_vector_max(pt::gt.Point{N, T}, direction, initial_guess::Tagged) where {N,T}
+    Tagged(SVector(pt))
+end
+
 function support_vector_max(simplex::Union{gt.AbstractSimplex, gt.AbstractFlexibleGeometry}, direction, initial_guess::Tagged)
     best_pt, score = gt.support_vector_max(simplex, gt.Vec(direction))
     Tagged(SVector(best_pt))

--- a/src/tagged_points.jl
+++ b/src/tagged_points.jl
@@ -30,3 +30,7 @@ end
 function any_inside(mesh::gt.AbstractMesh{gt.Point{N, T}}) where {N,T}
     Tagged(SVector(first(gt.vertices(mesh))))
 end
+
+function any_inside(point::gt.Point)
+    Tagged(SVector(point))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,6 +200,12 @@ end
         cache = CollisionCache(pt1, pt2)
         result = gjk!(cache, IdentityTransformation(), IdentityTransformation())
         @test isapprox(result.signed_distance, norm(pt1 - pt2))
+
+        pt1 = gt.Point(1,2,3.)
+        pt2 = gt.Point(3,4,5.)
+        cache = CollisionCache(pt1, pt2)
+        result = gjk!(cache, IdentityTransformation(), IdentityTransformation())
+        @test isapprox(result.signed_distance, norm(pt1 - pt2))
     end
 
     @testset "gjk intersecting lines" begin


### PR DESCRIPTION
I was surprised that `GeometryTypes.Vec` is used for points instead of `GeometryTypes.Point` (also in the GJK implementation in GeometryTypes). I'd like to at least also support `Point`, since `Vec` is meant to be used for free vectors (e.g. displacements) instead of bound vectors, as far as I understand.

I was doubting whether to make this change in GeometryTypes or here, but I feel like here is more appropriate, as  `GeometryTypes.support_vector_max` also returns a score, which is unused in this package and is just wasted computation (unless the compiler is able to optimize that away). In general, I feel like we should maybe stop relying on `GeometryTypes.support_vector_max` for this reason.