### PR TITLE
Improve benchmarks, fix inferability issue

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,11 +1,20 @@
 using BenchmarkTools
 using EnhancedGJK
-using CoordinateTransformations: IdentityTransformation, Translation
-import EnhancedGJK: projection_weights
 import GeometryTypes
-import StaticArrays: SVector
+using CoordinateTransformations: IdentityTransformation, Translation, AffineMap
+using EnhancedGJK: projection_weights, transform_simplex
+using StaticArrays: SVector, SMatrix
 
 const gt = GeometryTypes
+
+function comparison_benchmark(c1, c2)
+    group = BenchmarkGroup()
+    cache = CollisionCache(c1, c2)
+    group["geometrytypes"] = @benchmarkable gt.gjk($c1, $c2)
+    group["enhanced"] = @benchmarkable gjk!($cache, IdentityTransformation(), IdentityTransformation())
+    group["enhanced no cache"] = @benchmarkable gjk($c1, $c2)
+    return group
+end
 
 let
     suite = BenchmarkGroup()
@@ -26,20 +35,28 @@ let
         simplex = SVector{3}(SVector{2, Float64}[[1., -1], [1., 1], [1.5, 0]])
     )
 
-    suite["GeometryTypes comparisons"] = BenchmarkGroup()
-    let
-        group = suite["GeometryTypes comparisons"]
+    comparisons = suite["GeometryTypes comparisons"] = BenchmarkGroup()
+    comparisons["2d_simplex_simplex"] = let
         c1 = gt.Simplex(gt.Vec(0.,0), gt.Vec(0.,1), gt.Vec(1.,0),gt.Vec(1.,1))
         c2 = gt.Simplex(gt.Vec(4.,0.5))
-        group["geometrytypes simplex"] = @benchmarkable gt.gjk($c1, $c2)
+        comparison_benchmark(c1, c2)
+    end
+    comparisons["3d_point_box"] = let
+        c1 = gt.HyperRectangle(rand(gt.Vec{3}), rand(gt.Vec{3}))
+        c2 = rand(gt.Vec{3})
+        comparison_benchmark(c1, c2)
+    end
 
+    suite["transform_simplex"] = @benchmarkable transform_simplex(cache, poseA, poseB) setup = begin
+        c1 = gt.HyperRectangle(rand(gt.Vec{3}), rand(gt.Vec{3}))
+        c2 = gt.Simplex(rand(gt.Vec{3}))
         cache = CollisionCache(c1, c2)
-        group["enhanced simplex"] = @benchmarkable gjk!($cache, IdentityTransformation(), IdentityTransformation())
-
-        group["enhanced simplex no cache"] = @benchmarkable gjk($c1, $c2)
+        poseA = AffineMap(rand(SMatrix{3, 3}), rand(SVector{3}))
+        poseB = AffineMap(rand(SMatrix{3, 3}), rand(SVector{3}))
+        gjk!(cache, poseA, poseB)
     end
 
     tune!(suite)
     results = run(suite)
-    display(results)
+    show(IOContext(stdout, :compact => false), results)
 end

--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -71,6 +71,12 @@ end
     transform_simplex_impl(N, cache, poseA, poseB)
 end
 
+function transform_simplex_impl(N, cache, poseA, poseB)
+    Expr(:call, :(SVector),
+        [:((poseA(value(cache.simplex_points[$i].a)) -
+            poseB(value(cache.simplex_points[$i].b)))) for i in 1:(N + 1)]...)
+end
+
 # Note: it looks like this can be replaced with transpose(weights) * points in Julia 1.3 (before that, it's a lot slower)
 @generated function linear_combination(weights::StaticVector{N}, points::StaticVector{N}) where {N}
     expr = :(weights[1] * points[1])
@@ -81,12 +87,6 @@ end
         Base.@_inline_meta
         $expr
     end
-end
-
-function transform_simplex_impl(N, cache, poseA, poseB)
-    Expr(:call, :(SVector),
-        [:((poseA(value(cache.simplex_points[$i].a)) -
-            poseB(value(cache.simplex_points[$i].b)))) for i in 1:(N + 1)]...)
 end
 
 struct GJKResult{M, N, T}

--- a/src/johnson_distance.jl
+++ b/src/johnson_distance.jl
@@ -1,22 +1,3 @@
-"""
-    weights = projection_weights(simplex)
-
-This function implements Johnson's distance subalgorithm, as described in
-E. G. Gilbert, D. W. Johnson, and S. S. Keerthi, “A fast procedure for
-computing the distance between complex objects in three-dimensional space,”
-1988. Given a simplex (a length N+1 vector of points of dimension N), it
-returns weights such that dot(weights, simplex) yields the point in the convex
-hull of the simplex which is closest to the origin.
-
-This is the critical loop of the GJK algorithm, so it has been heavily optimized
-to precompute, inline, and unroll as much of the algorithm as possible. For a
-more readable (and much slower) implementation, see
-projection_weights_reference()
-"""
-@generated function projection_weights(simplex::SVector{M, SVector{N, T}}) where {M,N,T}
-    projection_weights_impl(simplex)
-end
-
 num_johnson_subsets(simplex_length::Integer) = 2^simplex_length - 1
 
 """
@@ -37,8 +18,26 @@ function johnson_subsets(simplex_length::Integer)
     subsets
 end
 
-function initial_deltas_impl(simplex_length, T)
-    num_subsets = num_johnson_subsets(simplex_length)
+"""
+    weights = projection_weights(simplex)
+
+This function implements Johnson's distance subalgorithm, as described in
+E. G. Gilbert, D. W. Johnson, and S. S. Keerthi, “A fast procedure for
+computing the distance between complex objects in three-dimensional space,”
+1988. Given a simplex (a length N+1 vector of points of dimension N), it
+returns weights such that dot(weights, simplex) yields the point in the convex
+hull of the simplex which is closest to the origin.
+
+This is the critical loop of the GJK algorithm, so it has been heavily optimized
+to precompute, inline, and unroll as much of the algorithm as possible. For a
+more readable (and much slower) implementation, see
+projection_weights_reference()
+"""
+@generated function projection_weights(simplex::SVector{M, SVector{N, T}}) where {M,N,T}
+    simplex_length = M
+    num_subsets = num_johnson_subsets(M)
+    subsets = johnson_subsets(M)
+    complements = .!subsets
 
     expr = quote
         deltas = zero(SVector{$num_subsets, SVector{$simplex_length, $T}})
@@ -53,24 +52,6 @@ function initial_deltas_impl(simplex_length, T)
         push!(expr.args, quote
             deltas = setindex(deltas, $(arg), $(2^(i - 1)))
         end)
-    end
-    expr
-end
-
-"""
-This is the function which actually computes the weight values.
-It returns an *expression* to compute that result, with all loops
-unrolled and all indices pre-computed based on the size and dimension
-of the simplex. For a more readable version of the same function, check
-out projection_weights_reference().
-"""
-function projection_weights_impl(::Type{SVector{M, SVector{N, T}}}) where {M,N,T}
-    num_subsets = num_johnson_subsets(M)
-    subsets = johnson_subsets(M)
-    complements = .!subsets
-
-    expr = quote
-        deltas = $(initial_deltas_impl(M, T))
     end
 
     for s in 1:(num_subsets - 1)

--- a/src/johnson_distance.jl
+++ b/src/johnson_distance.jl
@@ -40,14 +40,14 @@ projection_weights_reference()
     complements = .!subsets
 
     expr = quote
-        deltas = zero(SVector{$num_subsets, SVector{$simplex_length, $T}})
+        deltas = SVector(tuple($([zero(SVector{simplex_length, T}) for i = 1 : num_subsets]...)))
     end
 
     # Set the weight of every singleton subset to 1.
     for i in 1:simplex_length
         elements = [:(zero($T)) for j in 1:simplex_length]
         elements[i] = :(one($T))
-        arg = Expr(:call, :(SVector{$simplex_length, $T}), elements...)
+        arg = :(SVector{$simplex_length, $T}(tuple($(elements...))))
 
         push!(expr.args, quote
             deltas = setindex(deltas, $(arg), $(2^(i - 1)))


### PR DESCRIPTION
Reduces the 496 bytes of allocation for calling `projection_weights` with a 3D simplex to zero. The main issue was with

```julia
deltas = zero(SVector{$num_subsets, SVector{$simplex_length, $T}})
```

which apparently isn't inferable for sufficiently big `simplex_length`s.

Results of `3d_simplex_2` benchmark before:

```
  "3d_simplex_2" => BenchmarkTools.Trial: 
          memory estimate:  496 bytes
          allocs estimate:  1
          --------------
          minimum time:     58.515 ns (0.00% GC)
          median time:      61.949 ns (0.00% GC)
          mean time:        78.138 ns (18.39% GC)
          maximum time:     46.625 ?s (99.58% GC)
```

and after:

```
  "3d_simplex_2" => BenchmarkTools.Trial: 
          memory estimate:  0 bytes
          allocs estimate:  0
          --------------
          minimum time:     15.915 ns (0.00% GC)
          median time:      15.938 ns (0.00% GC)
          mean time:        16.579 ns (0.00% GC)
          maximum time:     46.735 ns (0.00% GC)
```

