### PR TITLE
GJKResult/API changes

### DIFF
--- a/gjk2.ipynb
+++ b/gjk2.ipynb
@@ -105,7 +105,7 @@
    ],
    "source": [
     "xs = linspace(-5, 5)\n",
-    "dists = [EnhancedGJK.gjk!(cache, IdentityTransformation(), Translation(SVector(x, 0))).signed_distance for x in xs]\n",
+    "dists = [separation_distance(EnhancedGJK.gjk!(cache, IdentityTransformation(), Translation(SVector(x, 0)))) for x in xs]\n",
     "plot(xs, dists, \"b.-\")"
    ]
   }

--- a/src/EnhancedGJK.jl
+++ b/src/EnhancedGJK.jl
@@ -16,7 +16,11 @@ export CollisionCache,
        gjk,
        GJKResult,
        NeighborMesh,
-       ReferenceDistance
+       ReferenceDistance,
+       closest_point_in_world,
+       closest_point_in_body,
+       separation_distance,
+       simplex_penetration_distance
 
 
 include("tagged_points.jl")

--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -111,6 +111,7 @@ function Base.getproperty(result::GJKResult, sym::Symbol)
 end
 
 closest_point_in_world(result::GJKResult) = linear_combination(result.simplex, result.weights)
+closest_point_in_body(result::GJKResult) = result.closest_point_in_body # just for symmetry with the world function
 separation_distance(result::GJKResult) = (@assert !result.in_collision; norm(closest_point_in_world(result)))
 simplex_penetration_distance(result::GJKResult) = penetration_distance(result.simplex)
 


### PR DESCRIPTION
Remove the `signed_distance` field from `GJKResult`, add `in_collision` and `weights` fields. Main reasons:

* penetration distance computation often accounts for a a significant fraction of total computation time, while there are cases where it's not even needed. So make computing it optional by having it be in a separate method
* I find the term `signed_distance` to be a bit disingenuous; in penetration we're not actually computing proper penetration distance. By having separate `separation_distance` and `simplex_penetration_distance` functions and talking about the difference in the readme, we're no longer lying.