### PR TITLE
Fix `gjk(a,a)`

### DIFF
--- a/src/gjk.jl
+++ b/src/gjk.jl
@@ -129,7 +129,8 @@ function gjk!(cache::CollisionCache,
         weights = projection_weights(simplex)
         min_weight, index_to_replace = findmin(weights)
         best_point = linear_combination(weights, simplex)
-        if min_weight > 0
+        if min_weight > 0 || best_point == zero(best_point)
+            # `simplex` contains the origin
             # Nominally in collision; but check for numerical issues
             separation_squared = best_point ⋅ best_point
             @assert separation_squared < sqrt(1_000_000 * eps(typeof(separation_squared)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,6 +241,12 @@ end
     end
 end
 
+@testset "starting simplex is origin" begin
+    hr = gt.HyperRectangle{3, Float64}([-1.0, -1.0, -1.0], [2.0, 2.0, 2.0])
+    result = gjk(hr, hr)
+    @test result.in_collision
+end
+
 @testset "benchmarks" begin
     include("../perf/runbenchmarks.jl")
 end


### PR DESCRIPTION
I don't know if this is the best way to handle this edge case. The issue would also be fixed if `projection_weights` returned e.g. `[0.25, 0.25, 0.25, 0.25]` in the case of a degenerate 3-simplex, instead of `[1.0, 0.0, 0.0, 0.0]`.