### PR TITLE
Fix #32, GeometryTypes vs GeometryBasics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ notifications:
 matrix:
   allow_failures:
     - julia: 1.0 # because of https://github.com/JuliaRobotics/EnhancedGJK.jl/pull/16#issuecomment-503319584
+    - julia: 1.1 # because of need for version range for MeshIO
     - julia: nightly
 branches:
   only:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ BenchmarkTools = "≥ 0.0.5"
 CoordinateTransformations = "≥ 0.3.0"
 FileIO = "≥ 0.3.0"
 GeometryTypes = "≥ 0.4.0"
-MeshIO = "≥ 0.0.6"
+MeshIO = "0.0.6 - 0.3.2"
 StaticArrays = "≥ 0.5.1"
 julia = "≥ 0.7.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EnhancedGJK"
 uuid = "3d39a06a-b57e-5769-b499-4d62b23c243f"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
@@ -16,7 +16,7 @@ FileIO = "≥ 0.3.0"
 GeometryTypes = "≥ 0.4.0"
 MeshIO = "0.0.6 - 0.3.2"
 StaticArrays = "≥ 0.5.1"
-julia = "≥ 0.7.0"
+julia = "≥ 1.4"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ result = gjk!(cache, Translation(SVector(0.1, 0)), IdentityTransformation())
 using MeshIO
 using FileIO
 mesh = load("test/meshes/r_foot_chull.obj")
-result = gjk(mesh, mesh, IdentityTransformation(), Translation(SVector(5., 0, 0)))
+result = EnhancedGJK.gjk(mesh, mesh, IdentityTransformation(), Translation(SVector(5., 0, 0)))
 @show separation_distance(result)
 ```
 


### PR DESCRIPTION
Restricted MeshIO compatibility to <= 0.3.2, edited README to add necessary qualification on call.